### PR TITLE
Adding console-access-protocol config to mitaka and newton bundles

### DIFF
--- a/calico-mitaka-juju2/bundle.yaml
+++ b/calico-mitaka-juju2/bundle.yaml
@@ -88,6 +88,7 @@ services:
     num_units: 1
     options:
       "network-manager": Neutron
+      "console-access-protocol": "vnc"
     annotations:
       "gui-x": "2931"
       "gui-y": "907.5"

--- a/calico-newton-juju2/bundle.yaml
+++ b/calico-newton-juju2/bundle.yaml
@@ -96,6 +96,7 @@ services:
     options:
       "openstack-origin": "cloud:xenial-newton"
       "network-manager": Neutron
+      "console-access-protocol": "vnc"
     annotations:
       "gui-x": "2931"
       "gui-y": "907.5"


### PR DESCRIPTION
  Nova-cloud-controller charm configuration 'console-access-protocol' need
  to be set to either 'vnc' or 'spice' for console of OpenStack instances
  to work.

Signed-off-by: Junaid Ali <junaidali.yahya@gmail.com>